### PR TITLE
id generation bug

### DIFF
--- a/grails-app/domain/com/grailsrocks/emailconfirmation/PendingEmailConfirmation.groovy
+++ b/grails-app/domain/com/grailsrocks/emailconfirmation/PendingEmailConfirmation.groovy
@@ -25,6 +25,7 @@ class PendingEmailConfirmation implements Serializable {
 	Date timestamp = new Date()
 
     static mapping = {
+	id generator: 'sequence'
         confirmationToken index:'emailconf_token_Idx'
         timestamp index:'emailconf_timestamp_Idx'
     }


### PR DESCRIPTION
This is a request to fix an issue I created in JIRA.  When an app has a globally configured id generator in the mapping block of Config.groovy, the app tries to use that type in the email confirmation plugin.  This plugin only accepts a Long and it should specify that in the Domain class so everything works.

http://jira.grails.org/browse/GPEMAILCONFIRMATION-34
